### PR TITLE
Prevent Exception from raising an Exception

### DIFF
--- a/Software/place.py
+++ b/Software/place.py
@@ -4,7 +4,7 @@ class PlaceState():
     OCCUPIED = 3  # The owner of the ticket number has started
 
 
-class RegistrationError:
+class RegistrationError(Exception):
     pass
 
 


### PR DESCRIPTION
RegistrationError gets raise'd, so it should be an Exception and behave
like one.

This fixes

```
>>> raise RegistrationError('test')
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: RegistrationError() takes no arguments
```